### PR TITLE
fix: centos building fixes

### DIFF
--- a/bins/broker/misc/FixedSizeUnorderedMap.h
+++ b/bins/broker/misc/FixedSizeUnorderedMap.h
@@ -29,7 +29,7 @@ template <typename Value>
 class FSReadLockedValue {
   MRWLock *_rwLock = nullptr;
   const Value *_value = nullptr;
-  std::atomic_bool _wasMoved{false};
+  std::atomic_bool _wasMoved = {false};
 
   void unlock() noexcept {
     if (_rwLock && _rwLock->isValid()) {

--- a/libs/libupmq/decaf/lang/Exception.cpp
+++ b/libs/libupmq/decaf/lang/Exception.cpp
@@ -55,7 +55,7 @@ class ExceptionData {
       : message(std::move(other.message)), cause(other.cause.release()), stackTrace(std::move(other.stackTrace)) {}
 
   ExceptionData &operator=(const ExceptionData &other) = default;
-  ExceptionData &operator=(ExceptionData &&other) noexcept = default;
+  ExceptionData &operator=(ExceptionData &&other) = default;
 };
 }  // namespace lang
 }  // namespace decaf


### PR DESCRIPTION
Hello. I've built this project on [centos:7](https://hub.docker.com/_/centos) instance. And I needed some changes for:
1. noexcept for default constructor
2. use of deleted function 'std::atomic_bool::atomic_bool

I must confess, I've built protobuf and poco. So, what do you thing about conan for that? It can be used for such cases.

P.s. cmake was built too