### PR TITLE
fix: failed selector tests

### DIFF
--- a/bins/broker/selector/SelectorExpression.cpp
+++ b/bins/broker/selector/SelectorExpression.cpp
@@ -990,7 +990,7 @@ class Parse {
 
   Expression *parseExactNumeric(const Token &token, bool isNegate) {
     int base = 0;
-    string s(0, '\0');
+    string s;
     s.reserve(token.val.size());
     std::remove_copy(token.val.begin(), token.val.end(), std::back_inserter(s), '_');
     if (s[1] == 'b' || s[1] == 'B') {
@@ -1019,6 +1019,7 @@ class Parse {
   Expression *parseApproxNumeric(const Token &token) {
     errno = 0;
     string s;
+    s.reserve(token.val.size());
     std::remove_copy(token.val.begin(), token.val.end(), std::back_inserter(s), '_');
     double value = std::strtod(s.c_str(), nullptr);
     if (!errno) {

--- a/bins/broker/selector/SelectorExpression.cpp
+++ b/bins/broker/selector/SelectorExpression.cpp
@@ -990,7 +990,8 @@ class Parse {
 
   Expression *parseExactNumeric(const Token &token, bool isNegate) {
     int base = 0;
-    string s(token.val.size(), 0);
+    string s(0, '\0');
+    s.reserve(token.val.size());
     std::remove_copy(token.val.begin(), token.val.end(), std::back_inserter(s), '_');
     if (s[1] == 'b' || s[1] == 'B') {
       base = 2;

--- a/tests/brokertest/SelectorTest.cpp
+++ b/tests/brokertest/SelectorTest.cpp
@@ -34,8 +34,14 @@ void SelectorTest::SetUp() {
 TEST_F(SelectorTest, testBasicSelectors) {
   assertSelector("name = 'John'", false);
   assertSelector("name = 'James'", true);
+  assertSelector("rank = 123", true);
+  assertSelector("rank = 124", false);
   assertSelector("rank > 100", true);
+  assertSelector("rank < 124", true);
+  assertSelector("rank > 124", false);
+  assertSelector("rank < 123", false);
   assertSelector("rank >= 123", true);
+  assertSelector("rank <= 124", true);
   assertSelector("rank >= 124", false);
 }
 


### PR DESCRIPTION
I got 5 failed tests:
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] SelectorTest.testBasicSelectors
[  FAILED  ] SelectorTest.testPropertyTypes
[  FAILED  ] SelectorTest.testAndSelectors
[  FAILED  ] SelectorTest.testOrSelectors
[  FAILED  ] SelectorTest.testBetween

There was a mistake in parseExactNumeric