### PR TITLE
fix: stable session rebegin

### DIFF
--- a/bins/broker/session/Session.cpp
+++ b/bins/broker/session/Session.cpp
@@ -135,14 +135,14 @@ void Session::rebegin() const {
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().begin(*this, item);
   }
-  _rebegin_mutex.unlock();
+  _rebeginMutex.unlock();
 }
 void Session::commit() const {
   if (_stateStack.last() == State::COMMIT) {
     return;
   }
   if (isTransactAcknowledge()) {
-    _rebegin_mutex.lock();
+    _rebeginMutex.lock();
   }
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().commit(*this, item);
@@ -155,7 +155,7 @@ void Session::abort(bool destruct) const {
     return;
   }
   if (isTransactAcknowledge() && !destruct) {
-    _rebegin_mutex.lock();
+    _rebeginMutex.lock();
   }
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().abort(*this, item);
@@ -171,7 +171,7 @@ void Session::saveMessage(const MessageDataContainer &sMessage) {
 }
 std::string Session::txName() const {
   if (isTransactAcknowledge()) {
-    std::lock_guard<std::recursive_mutex> lock(_rebegin_mutex);
+    std::lock_guard<std::recursive_mutex> lock(_rebeginMutex);
     return _id + "_" + std::to_string(_txCounter);
   }
   return _id + "_" + std::to_string(_txCounter);

--- a/bins/broker/session/Session.cpp
+++ b/bins/broker/session/Session.cpp
@@ -135,10 +135,14 @@ void Session::rebegin() const {
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().begin(*this, item);
   }
+  _rebegin_mutex.unlock();
 }
 void Session::commit() const {
   if (_stateStack.last() == State::COMMIT) {
     return;
+  }
+  if (isTransactAcknowledge()) {
+    _rebegin_mutex.lock();
   }
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().commit(*this, item);
@@ -149,6 +153,9 @@ void Session::commit() const {
 void Session::abort(bool destruct) const {
   if (_stateStack.last() == State::ABORT) {
     return;
+  }
+  if (isTransactAcknowledge() && !destruct) {
+    _rebegin_mutex.lock();
   }
   for (const auto &item : _destinations) {
     EXCHANGE::Instance().abort(*this, item);
@@ -162,7 +169,13 @@ void Session::saveMessage(const MessageDataContainer &sMessage) {
   addToUsed(sMessage.message().destination_uri());
   EXCHANGE::Instance().saveMessage(*this, sMessage);
 }
-std::string Session::txName() const { return _id + "_" + std::to_string(_txCounter); }
+std::string Session::txName() const {
+  if (isTransactAcknowledge()) {
+    std::lock_guard<std::recursive_mutex> lock(_rebegin_mutex);
+    return _id + "_" + std::to_string(_txCounter);
+  }
+  return _id + "_" + std::to_string(_txCounter);
+}
 void Session::addSender(const MessageDataContainer &sMessage) {
   addToUsed(sMessage.sender().destination_uri());
   EXCHANGE::Instance().addSender(*this, sMessage);

--- a/bins/broker/session/Session.h
+++ b/bins/broker/session/Session.h
@@ -111,7 +111,7 @@ class Session {
   const Connection &_connection;
   mutable std::atomic_int _txCounter;
   mutable CircularQueue<State> _stateStack;
-  mutable std::recursive_mutex _rebegin_mutex;
+  mutable std::recursive_mutex _rebeginMutex;
   void rebegin() const;
 
  public:

--- a/bins/broker/session/Session.h
+++ b/bins/broker/session/Session.h
@@ -111,6 +111,7 @@ class Session {
   const Connection &_connection;
   mutable std::atomic_int _txCounter;
   mutable CircularQueue<State> _stateStack;
+  mutable std::recursive_mutex _rebegin_mutex;
   void rebegin() const;
 
  public:

--- a/tests/brokertest/TransactionTest.cpp
+++ b/tests/brokertest/TransactionTest.cpp
@@ -49,7 +49,7 @@ TEST_F(TransactionTest, testSendReceiveTransactedBatches) {
       std::unique_ptr<TextMessage> message;
       EXPECT_NO_THROW(message.reset(dynamic_cast<TextMessage *>(consumer->receive(3000)))) << "Receive Shouldn't throw a Message here:";
 
-      EXPECT_TRUE(message != nullptr) << "Failed to receive all messages in batch";
+      ASSERT_TRUE(message != nullptr) << "Failed to receive all messages in batch";
       EXPECT_TRUE(msg[i] == message->getText());
     }
 
@@ -95,13 +95,12 @@ TEST_F(TransactionTest, testSendRollback) {
   // validates that the rollbacked was not consumed
   EXPECT_NO_THROW(session->commit());
 
-  EXPECT_TRUE(inbound1 != nullptr);
-  EXPECT_TRUE(inbound2 != nullptr);
-
+  ASSERT_TRUE(inbound1 != nullptr);
   outbound1->setReadable();
-  outbound2->setReadable();
-
   EXPECT_EQ(outbound1->getText(), inbound1->getText());
+
+  ASSERT_TRUE(inbound2 != nullptr);
+  outbound2->setReadable();
   EXPECT_EQ(outbound2->getText(), inbound2->getText())
       << "invalid order : ou1-id[" << outbound1->getCMSMessageID() << "] : in1-id[" << inbound1->getCMSMessageID() << "]\n"
       << "invalid order : ou2-id[" << outbound2->getCMSMessageID() << "] : in2-id[" << inbound2->getCMSMessageID() << "]";
@@ -132,7 +131,7 @@ TEST_F(TransactionTest, testSendRollbackCommitRollback) {
   std::unique_ptr<TextMessage> inbound1(dynamic_cast<TextMessage *>(consumer->receive(3000)));
   std::unique_ptr<TextMessage> inboundEmpty(dynamic_cast<TextMessage *>(consumer->receive(3000)));
   EXPECT_TRUE(nullptr == inboundEmpty) << "must be empty, but : " << inboundEmpty->getText();
-  EXPECT_TRUE(inbound1 != nullptr);
+  ASSERT_TRUE(inbound1 != nullptr);
   outbound1->setReadable();
   EXPECT_EQ(outbound1->getText(), inbound1->getText());
 
@@ -141,7 +140,7 @@ TEST_F(TransactionTest, testSendRollbackCommitRollback) {
   inbound1.reset(dynamic_cast<TextMessage *>(consumer->receive(5000)));
   inboundEmpty.reset(dynamic_cast<TextMessage *>(consumer->receive(5000)));
   EXPECT_TRUE(nullptr == inboundEmpty) << "expect empty, but got =>" << inboundEmpty->getText();
-  EXPECT_TRUE(inbound1 != nullptr);
+  ASSERT_TRUE(inbound1 != nullptr);
   outbound2->setReadable();
   EXPECT_EQ(outbound1->getText(), inbound1->getText());
 
@@ -182,11 +181,12 @@ TEST_F(TransactionTest, testSendSessionClose) {
   // validates that the rolled back was not consumed
   EXPECT_NO_THROW(cmsProvider->getSession()->commit());
 
-  EXPECT_TRUE(inbound1 != nullptr);
-  EXPECT_TRUE(inbound2 != nullptr);
+  ASSERT_TRUE(inbound1 != nullptr);
   outbound1->setReadable();
-  outbound2->setReadable();
   EXPECT_TRUE(outbound1->getText() == inbound1->getText());
+
+  ASSERT_TRUE(inbound2 != nullptr);
+  outbound2->setReadable();
   EXPECT_TRUE(outbound2->getText() == inbound2->getText());
 }
 
@@ -216,7 +216,7 @@ TEST_F(TransactionTest, testWithTTLSet) {
     // receives the second message
     std::unique_ptr<TextMessage> inbound1;
     EXPECT_NO_THROW(inbound1.reset(dynamic_cast<TextMessage *>(consumer->receive(3000))));
-    EXPECT_TRUE(inbound1 != nullptr);
+    ASSERT_TRUE(inbound1 != nullptr);
     EXPECT_EQ(msg[i].first, inbound1->getCMSMessageID());
     EXPECT_EQ(msg[i].second, inbound1->getText());
   }
@@ -247,7 +247,7 @@ TEST_F(TransactionTest, testSessionCommitAfterConsumerClosed) {
   connection->start();
 
   std::unique_ptr<cms::Message> message(consumer->receive(3000));
-  EXPECT_TRUE(message.get() != nullptr);
+  ASSERT_TRUE(message.get() != nullptr);
 
   consumer->close();
   session->commit();


### PR DESCRIPTION
When we have a banch of resources, we can see a picture below:
```
message:           |=====|
commit:                    |=======|
make consumer cash:                  |=====|
.................................................................................
abort:                                                      |=======|
remake consumer cash:                                               |=====|
```
So, with commit `_txCounter` becomses bigger. Messages get marked as sent with new `txName` (`setMessagesToWasSent`) while makeing consumer cash. After all, abort cleans consumer select and resets marked messages (`setMessagesToNotSent`). It works!

But if the resources are not enough, we could lost some messages:
```
message:           |=====|
commit:                    |=========|
make consumer cash:          !*****!
.................................................................................
abort:                                                      |=======|
remake consumer cash:                                               |=====|
```
As a result, `_txCounter` becomes bigger after message marking. And there are messages with wrong `txName`. In the end, messages are getting lost after abort as consumer select becomes clean and reset proceeds with a brand new `txName` filter.